### PR TITLE
Various cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 include(FeatureSummary)
 
-find_package(YARP 3.0 REQUIRED
-                      COMPONENTS OS
-                                 sig
-                                 dev
-                                 math)
+find_package(YARP 3.2.0 REQUIRED
+                        COMPONENTS OS
+                                   sig
+                                   dev
+                                   math)
 
 find_package(ViconSDK REQUIRED)
 
@@ -50,9 +50,5 @@ yarp_install(TARGETS yarp_vicon
              COMPONENT runtime
              LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
              ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
-yarp_install(FILES vicon.ini
-             COMPONENT runtime
-             DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
-
 
 set_property(TARGET yarp_vicon PROPERTY FOLDER "Plugins/Device")

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Using this device, it is possible to retrieve the Vicon markers information in t
 ### Linux
 - Setup the `~/.bash_aliases`
   ```bash
-  export ViconSDK_ROOT=location/of/the/ViconSDK/libraries
-  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ViconSDK_ROOT}
+  export ViconSDK_DIR=location/of/the/ViconSDK/libraries
+  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ViconSDK_DIR}
   ```
 - Configure and make
   ```bash
@@ -33,8 +33,8 @@ Using this device, it is possible to retrieve the Vicon markers information in t
 ### Windows
 - Setup the environment variables
   ```bash
-    setx ViconSDK_ROOT "location/of/the/ViconSDK/libraries"
-    setx PATH=%PATH%;ViconSDK_ROOT 
+    setx ViconSDK_DIR "location/of/the/ViconSDK/libraries"
+    setx PATH=%PATH%;ViconSDK_DIR
   ```
   :bulb: You can also set the environment variables using a GUI called [Rapid Environment Editor](https://www.rapidee.com/en/about)
   

--- a/cmake/FindViconSDK.cmake
+++ b/cmake/FindViconSDK.cmake
@@ -16,29 +16,19 @@
 # ViconSDK_LIBRARIES, the libraries to link against
 # ViconSDK_FOUND, if false, you cannot build anything that requires ViconSDK
 
-######################################################################## 
+############################################################################
 
-find_path(ViconSDK_INCLUDE_DIR NAMES DataStreamClient.h HINTS $ENV{ViconSDK_ROOT})
-if(WIN32)        
-        find_library(ViconSDK_LIBRARY NAMES ViconDataStreamSDK_CPP.dll ViconDataStreamSDK_CPP.lib HINTS $ENV{ViconSDK_ROOT})
-endif(WIN32)
+find_path(ViconSDK_INCLUDE_DIR NAMES DataStreamClient.h
+                               HINTS $ENV{ViconSDK_DIR})
 
-if(UNIX AND NOT APPLE)
-        find_library(ViconSDK_LIBRARY NAMES libViconDataStreamSDK_CPP.so HINTS $ENV{ViconSDK_ROOT})
-endif(UNIX AND NOT APPLE)
- 
-if(APPLE)
-        find_library(ViconSDK_LIBRARY NAMES libViconDataStreamSDK_CPP.dylib HINTS $ENV{ViconSDK_ROOT})
-endif(APPLE)
+find_library(ViconSDK_LIBRARY NAMES ViconDataStreamSDK_CPP
+                              HINTS $ENV{ViconSDK_DIR})
 
- 
-if (ViconSDK_INCLUDE_DIR AND ViconSDK_LIBRARY) 
-	set(ViconSDK_FOUND TRUE) 
+if (ViconSDK_INCLUDE_DIR AND ViconSDK_LIBRARY)
+  set(ViconSDK_FOUND TRUE)
 else () 
-	set(ViconSDK_FOUND FALSE) 
+  set(ViconSDK_FOUND FALSE)
 endif () 
- 
- 
 
 # TSS: backwards compatibility
-set(ViconSDK_LIBRARIES ${ViconSDK_LIBRARY}) 
+set(ViconSDK_LIBRARIES ${ViconSDK_LIBRARY})

--- a/cmake/FindViconSDK.cmake
+++ b/cmake/FindViconSDK.cmake
@@ -1,3 +1,12 @@
+################################################################################
+#                                                                              #
+# Copyright (C) 2019 Fondazione Istitito Italiano di Tecnologia (IIT)          #
+# All Rights Reserved.                                                         #
+#                                                                              #
+################################################################################
+
+# @author Nicolo' Genesio <nicolo.genesio@iit.it>
+
 #
 # Find the ViconSDK includes and library
 #

--- a/vicon.ini
+++ b/vicon.ini
@@ -1,4 +1,0 @@
-[plugin vicon]
-type device
-name vicon
-library yarp_vicon


### PR DESCRIPTION
This PR fixes #8 .

Moreover the ViconSDK_ROOT (deprecated by cmake) has been changed to ViconSDK_DIR.

Finally, yarp mininimum required is 3.2.0 for the automatic ini generation(see https://github.com/robotology/yarp/pull/1964).
If it is a problem I can revert that commit

On linux works fine.

cc @GiulioRomualdi @prashanthr05 